### PR TITLE
Auto refresh reports

### DIFF
--- a/scripts/ReportImprovements/report-improvements.user.js
+++ b/scripts/ReportImprovements/report-improvements.user.js
@@ -160,15 +160,11 @@
             method: 'GET',
             url: window.location.href,
             onload: function (response) {
-                console.log('[Live Refresh] Response loaded');
                 const parser = new DOMParser();
                 const doc = parser.parseFromString(response.responseText, 'text/html');
-                console.log('[Live Refresh] Parsed document:', doc);
     
                 const openReportsNew = Array.from(doc.querySelectorAll('.structItemContainer'))[0]
                     .querySelectorAll('.structItem.structItem--report');
-                    
-                console.log('[Live Refresh] Fetched reports:', openReportsNew.length);
 
                 const realContainers = Array.from(document.querySelectorAll('.structItemContainer'))
                     .filter(c => !c.closest('#xf-report-hoist'));
@@ -179,17 +175,12 @@
     
                 const newKeys = new Set([...openReportsNew].map(getReportKey));
                 const currentKeys = new Set([...currentReports].map(getReportKey));
-
-                console.log('[Live Refresh] Current reports:', currentReports.length);
-                console.log('[Live Refresh] New report keys:', newKeys.size);
-                console.log('[Live Refresh] Current report keys:', currentKeys.size);
     
                 currentReports.forEach(r => {
                     const key = getReportKey(r);
                     if (key && !newKeys.has(key)) {
                         console.log(`[Live Refresh] Report ${key} is missing (resolved)`);
-                        r.style.opacity = '0.5';
-                        r.style.background = '#444';
+                        r.style.display = 'none';
                     }
                 });
     
@@ -198,7 +189,6 @@
                     openReportsNew.forEach(r => {
                         const key = getReportKey(r);
                         if (key && !currentKeys.has(key)) {
-                            console.log(`[Live Refresh] New report detected: ${key}`);
                             if (!container.querySelector(`[href="${key}"]`)) {
                                 const clone = r.cloneNode(true);
                                 container.insertBefore(clone, container.firstChild);

--- a/scripts/ReportImprovements/report-improvements.user.js
+++ b/scripts/ReportImprovements/report-improvements.user.js
@@ -139,14 +139,14 @@
         popup.style.display = 'none';
 
         popup.innerHTML = `
-            <div id="xf-live-refresh-warning" style="color:rgb(218, 20, 20); margin-top: 8px; display: none;">
-                Live refresh is enabled in another tab. This tab will not auto-update.
-            </div>
             <label style="font-weight: bold; display:block; margin-bottom: 5px;">Subforums to highlight (one per line):</label>
             <textarea id="xf-forum-editor" style="width: 200px; height: 100px;"></textarea><br>
             <label style="display:block; margin-top:10px;">
                 <input type="checkbox" id="xf-live-refresh-toggle"> Live update reports
             </label>
+            <div id="xf-live-refresh-warning" style="color:rgb(218, 20, 20); margin-top: 8px; display: none;">
+                Live refresh is already enabled in another tab.
+            </div>
             <button id="xf-save-forums" style="margin-top: 8px;">Filter</button>
         `;
 
@@ -255,11 +255,17 @@
 
     function startHeartbeat() {
         setInterval(() => {
-            const data = {
-                tabId: TAB_ID,
-                timestamp: Date.now()
-            };
-            localStorage.setItem(HEARTBEAT_KEY, JSON.stringify(data));
+            const data = JSON.parse(localStorage.getItem(HEARTBEAT_KEY) || '{}');
+            const timeSinceLastBeat = Date.now() - (data.timestamp || 0);
+            const isStale = timeSinceLastBeat > 7000;
+    
+            if (data.tabId === TAB_ID || isStale) {
+                const newBeat = {
+                    tabId: TAB_ID,
+                    timestamp: Date.now()
+                };
+                localStorage.setItem(HEARTBEAT_KEY, JSON.stringify(newBeat));
+            }
         }, 3000);
     }
 

--- a/scripts/ReportImprovements/report-improvements.user.js
+++ b/scripts/ReportImprovements/report-improvements.user.js
@@ -180,7 +180,7 @@
                     const key = getReportKey(r);
                     if (key && !newKeys.has(key)) {
                         console.log(`[Live Refresh] Report ${key} is missing (resolved)`);
-                        r.style.display = 'none';
+                        r.remove();
                     }
                 });
     

--- a/scripts/ReportImprovements/report-improvements.user.js
+++ b/scripts/ReportImprovements/report-improvements.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Report Improvements
-// @version      1.4
+// @version      1.5.0
 // @description  Various improvements to XenForo reports
 // @author       Jindosh
 // @match        *://*/reports/*

--- a/scripts/ReportImprovements/report-improvements.user.js
+++ b/scripts/ReportImprovements/report-improvements.user.js
@@ -193,15 +193,19 @@
                     }
                 });
     
-                const container = document.querySelectorAll('.structItemContainer')[0];
-                openReportsNew.forEach(r => {
-                    const key = getReportKey(r);
-                    if (key && !currentKeys.has(key)) {
-                        console.log(`[Live Refresh] New report detected: ${key}`);
-                        const clone = r.cloneNode(true);
-                        container.insertBefore(clone, container.firstChild);
-                    }
-                });
+                const container = realContainers.length > 0 ? realContainers[0] : null;
+                if (container) {
+                    openReportsNew.forEach(r => {
+                        const key = getReportKey(r);
+                        if (key && !currentKeys.has(key)) {
+                            console.log(`[Live Refresh] New report detected: ${key}`);
+                            if (!container.querySelector(`[href="${key}"]`)) {
+                                const clone = r.cloneNode(true);
+                                container.insertBefore(clone, container.firstChild);
+                            }
+                        }
+                    });
+                }
     
                 hoistReports();
             },

--- a/scripts/ReportImprovements/report-improvements.user.js
+++ b/scripts/ReportImprovements/report-improvements.user.js
@@ -14,7 +14,7 @@
 
     const STORAGE_KEY = 'xf-report-filter-allowedForums';
     const LIVE_REFRESH_KEY = 'xf-report-filter-liveRefreshEnabled';
-    const REFRESH_INTERVAL = 10000;
+    const REFRESH_INTERVAL = 15000;
     const ICON_URL = 'https://raw.githubusercontent.com/Kirin-Jindosh/forum-stuff/refs/heads/dev/scripts/ReportImprovements/PepeHmmm.png';
 
     let refreshIntervalId = null;
@@ -125,10 +125,10 @@
         popup.style.display = 'none';
 
         popup.innerHTML = `
-            <label style="font-weight: bold; display:block; margin-bottom: 5px;">Subforums (one per line):</label>
+            <label style="font-weight: bold; display:block; margin-bottom: 5px;">Subforums to highlight (one per line):</label>
             <textarea id="xf-forum-editor" style="width: 200px; height: 100px;"></textarea><br>
             <label style="display:block; margin-top:10px;">
-                <input type="checkbox" id="xf-live-refresh-toggle"> Live refresh (every 10s)
+                <input type="checkbox" id="xf-live-refresh-toggle"> Live update reports
             </label>
             <button id="xf-save-forums" style="margin-top: 8px;">Filter</button>
         `;
@@ -181,8 +181,8 @@
                 const currentKeys = new Set([...currentReports].map(getReportKey));
 
                 console.log('[Live Refresh] Current reports:', currentReports.length);
-                console.log('[Live Refresh] New report keys:', newKeys.length);
-                console.log('[Live Refresh] Current report keys:', currentKeys.length);
+                console.log('[Live Refresh] New report keys:', newKeys.size);
+                console.log('[Live Refresh] Current report keys:', currentKeys.size);
     
                 currentReports.forEach(r => {
                     const key = getReportKey(r);

--- a/scripts/ReportImprovements/report-improvements.user.js
+++ b/scripts/ReportImprovements/report-improvements.user.js
@@ -12,7 +12,11 @@
     'use strict';
 
     const STORAGE_KEY = 'xf-report-filter-allowedForums';
-    const HMMM = 'https://raw.githubusercontent.com/Kirin-Jindosh/forum-stuff/refs/heads/main/scripts/ReportImprovements/PepeHmmm.png'
+    const LIVE_REFRESH_KEY = 'xf-report-filter-liveRefreshEnabled';
+    const REFRESH_INTERVAL = 10000;
+    const ICON_URL = 'https://raw.githubusercontent.com/Kirin-Jindosh/forum-stuff/refs/heads/dev/scripts/ReportImprovements/PepeHmmm.png';
+
+    let refreshIntervalId = null;
 
     function getAllowedForums() {
         const stored = localStorage.getItem(STORAGE_KEY);
@@ -24,51 +28,62 @@
         localStorage.setItem(STORAGE_KEY, JSON.stringify(forums));
     }
 
-    function hoistReports() {
+    function isLiveRefreshEnabled() {
+        return localStorage.getItem(LIVE_REFRESH_KEY) === 'true';
+    }
+
+    function setLiveRefreshEnabled(enabled) {
+        localStorage.setItem(LIVE_REFRESH_KEY, enabled.toString());
+    }
+
+    function getReportKey(reportElement) {
+        const link = reportElement.querySelector('a.structItem-title');
+        return link ? link.href : null;
+    }
+
+    function hoistReports(fromDocument = document) {
         const allowedForums = getAllowedForums().map(f => f.toLowerCase());
         const existingSection = document.getElementById('xf-report-hoist');
         if (existingSection) existingSection.remove();
-    
+
         if (allowedForums.length === 0) return;
-    
-        const allBlocks = document.querySelectorAll('.structItemContainer');
-    
+
+        const allBlocks = fromDocument.querySelectorAll('.structItemContainer');
+
         const hoistedContainer = document.createElement('div');
         hoistedContainer.id = 'xf-report-hoist';
         hoistedContainer.className = 'block';
         hoistedContainer.style.marginBottom = '20px';
-    
+
         const inner = document.createElement('div');
         inner.className = 'block-container';
         hoistedContainer.appendChild(inner);
-    
+
         const header = document.createElement('div');
         header.className = 'block-header';
         header.innerHTML = `<span class="block-header--title">Filtered reports:</span>`;
         inner.appendChild(header);
-    
+
         const body = document.createElement('div');
         body.className = 'structItemContainer';
         inner.appendChild(body);
-    
+
         let matchCount = 0;
-    
+
         const openBlock = allBlocks[0];
         if (openBlock) {
             const reports = openBlock.querySelectorAll('.structItem.structItem--report');
             reports.forEach(report => {
                 const forumLink = report.querySelector('.structItem-forum a');
-                if (forumLink) {
-                    const forumName = forumLink.textContent.trim().toLowerCase();
-                    if (allowedForums.some(f => forumName.includes(f))) {
-                        const clone = report.cloneNode(true);
-                        body.appendChild(clone);
-                        matchCount++;
-                    }
+                const forumName = forumLink?.textContent.trim().toLowerCase() ?? '';
+                if (allowedForums.some(f => forumName.includes(f))) {
+                    const clone = report.cloneNode(true);
+                    body.appendChild(clone);
+                    matchCount++;
                 }
             });
         }
-    
+
         if (matchCount > 0) {
             const mainList = document.querySelector('.p-body-main .block-container');
             if (mainList) {
@@ -87,7 +102,7 @@
         btn.style.zIndex = '1000';
         btn.style.width = '40px';
         btn.style.height = '40px';
-        btn.style.backgroundImage = `url('${HMMM}')`; 
+        btn.style.backgroundImage = `url('${ICON_URL}')`;
         btn.style.backgroundSize = 'contain';
         btn.style.backgroundRepeat = 'no-repeat';
         btn.style.backgroundColor = 'transparent';
@@ -111,6 +126,9 @@
         popup.innerHTML = `
             <label style="font-weight: bold; display:block; margin-bottom: 5px;">Subforums (one per line):</label>
             <textarea id="xf-forum-editor" style="width: 200px; height: 100px;"></textarea><br>
+            <label style="display:block; margin-top:10px;">
+                <input type="checkbox" id="xf-live-refresh-toggle"> Live refresh (every 10s)
+            </label>
             <button id="xf-save-forums" style="margin-top: 8px;">Filter</button>
         `;
 
@@ -119,7 +137,8 @@
         btn.addEventListener('click', () => {
             const current = getAllowedForums();
             document.getElementById('xf-forum-editor').value = current.join('\n');
-            popup.style.display = (popup.style.display === 'none') ? 'block' : 'none';
+            document.getElementById('xf-live-refresh-toggle').checked = isLiveRefreshEnabled();
+            popup.style.display = popup.style.display === 'none' ? 'block' : 'none';
         });
 
         document.getElementById('xf-save-forums').addEventListener('click', () => {
@@ -128,19 +147,66 @@
                 .map(f => f.trim())
                 .filter(f => f.length > 0);
             saveAllowedForums(lines);
+            setLiveRefreshEnabled(document.getElementById('xf-live-refresh-toggle').checked);
             hoistReports();
             popup.style.display = 'none';
+            restartLiveRefresh();
         });
     }
 
-    function setupObserver() {
-        const container = document.querySelector('.structItemContainer');
-        if (container) {
-            const observer = new MutationObserver(() => {
-                hoistReports();
+    async function checkForReportUpdates() {
+        try {
+            const res = await fetch(window.location.href, { credentials: 'include' });
+            const text = await res.text();
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(text, 'text/html');
+
+            const openReportsNew = Array.from(doc.querySelectorAll('.structItemContainer'))[0]
+                .querySelectorAll('.structItem.structItem--report');
+
+            const currentReports = document.querySelectorAll('.structItemContainer')[0]
+                .querySelectorAll('.structItem.structItem--report');
+
+            const newKeys = new Set([...openReportsNew].map(getReportKey));
+            const currentKeys = new Set([...currentReports].map(getReportKey));
+
+            currentReports.forEach(r => {
+                const key = getReportKey(r);
+                if (key && !newKeys.has(key)) {
+                    r.style.opacity = '0.5';
+                    r.style.background = '#590c0c';
+                }
             });
-            observer.observe(container, { childList: true, subtree: true });
+
+            const container = document.querySelectorAll('.structItemContainer')[0];
+            openReportsNew.forEach(r => {
+                const key = getReportKey(r);
+                if (key && !currentKeys.has(key)) {
+                    const clone = r.cloneNode(true);
+                    container.insertBefore(clone, container.firstChild);
+                }
+            });
+
+            hoistReports();
+
+        } catch (err) {
+            console.error('Live refresh failed:', err);
         }
+    }
+
+    function startLiveRefresh() {
+        if (refreshIntervalId) return;
+        refreshIntervalId = setInterval(checkForReportUpdates, REFRESH_INTERVAL);
+    }
+
+    function stopLiveRefresh() {
+        clearInterval(refreshIntervalId);
+        refreshIntervalId = null;
+    }
+
+    function restartLiveRefresh() {
+        stopLiveRefresh();
+        if (isLiveRefreshEnabled()) startLiveRefresh();
     }
 
     function waitForReportsContainer(callback) {
@@ -156,7 +222,6 @@
     waitForReportsContainer(() => {
         hoistReports();
         createSettingsUI();
-        setupObserver();
+        restartLiveRefresh();
     });
-
 })();


### PR DESCRIPTION
Script now automatically refreshes reports once every 15 seconds. 
First tab to enable this becomes the 'master' tab, which disables other tabs from using the auto re fresh until the master tab becomes stale.
